### PR TITLE
SS6 compatibility: update composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.3",
-        "silverstripe/recipe-plugin": "2.x-dev",
+        "silverstripe/recipe-plugin": "^2.1",
         "silverstripe/recipe-cms": "^6.2",
         "silverstripe/contentreview": "6.x-dev",
         "silverstripe/sharedraftcontent": "4.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/recipe-plugin": "2.x-dev",
-        "silverstripe/recipe-cms": "6.x-dev",
+        "silverstripe/recipe-cms": "^6.2",
         "silverstripe/contentreview": "6.x-dev",
         "silverstripe/sharedraftcontent": "4.x-dev",
         "symbiote/silverstripe-advancedworkflow": "7.x-dev"


### PR DESCRIPTION
## Summary
- Fix recipe-cms constraint to `^6.2` for stable SS6 compatibility
- Fix recipe-plugin constraint to `^2.1` for stable SS6 compatibility